### PR TITLE
Add alternate DFS solution for finding root-to-leaf paths

### DIFF
--- a/May 2025 GFG SOLUTION/May-07.java
+++ b/May 2025 GFG SOLUTION/May-07.java
@@ -1,0 +1,17 @@
+class Solution {
+    public static ArrayList<ArrayList<Integer>> Paths(Node root) {
+        ArrayList<ArrayList<Integer>> result = new ArrayList<>();
+        if (root != null) dfs(root, new ArrayList<>(), result);
+        return result;
+    }
+    
+    private static void dfs(Node node, ArrayList<Integer> path, ArrayList<ArrayList<Integer>> result) {
+        path.add(node.data);
+        if (node.left == null && node.right == null) result.add(new ArrayList<>(path));
+        else {
+            if (node.left != null) dfs(node.left, path, result);
+            if (node.right != null) dfs(node.right, path, result);
+        }
+        path.remove(path.size() - 1);
+    }
+}


### PR DESCRIPTION

Implement a safer DFS approach for finding all root-to-leaf paths in a binary tree.

The problem can be found at the following link: 🔗 [Question Link](https://www.geeksforgeeks.org/problems/root-to-leaf-paths/1)

```java
class Solution {
    public static ArrayList<ArrayList<Integer>> Paths(Node root) {
        // code here
        ArrayList<ArrayList<Integer>> result = new ArrayList<>();
        if (root != null) dfs(root, new ArrayList<>(), result);
        return result;
    }
    
    private static void dfs(Node node, ArrayList<Integer> path, ArrayList<ArrayList<Integer>> result) {
        path.add(node.data);
        if (node.left == null && node.right == null) result.add(new ArrayList<>(path));
        else {
            if (node.left != null) dfs(node.left, path, result);
            if (node.right != null) dfs(node.right, path, result);
        }
        path.remove(path.size() - 1);
    }
}
```